### PR TITLE
[`api`] Logging and error reporting

### DIFF
--- a/api/env.ts
+++ b/api/env.ts
@@ -11,6 +11,9 @@ const appName = process.env.APP_NAME?.replace(/^W/g, "");
  * @see https://github.com/af/envalid
  */
 export default cleanEnv(process.env, {
+  GOOGLE_CLOUD_PROJECT: str(),
+  GOOGLE_CLOUD_REGION: str(),
+
   APP_NAME: str(),
   APP_ORIGIN: url(),
   APP_ENV: str({ choices: ["prod", "test", "local"] }),

--- a/api/errors.ts
+++ b/api/errors.ts
@@ -3,7 +3,7 @@
 
 import { ErrorRequestHandler } from "express";
 import { isHttpError } from "http-errors";
-import { reportError } from "./core";
+import { log } from "./core";
 
 /**
  * Renders an error page.
@@ -14,7 +14,7 @@ export const handleError: ErrorRequestHandler = function (
   res,
   next, // eslint-disable-line @typescript-eslint/no-unused-vars
 ) {
-  reportError(err, req);
+  log(req, res, "ERROR", err);
 
   const statusCode = isHttpError(err) ? err.statusCode : 500;
   res.status(statusCode);

--- a/api/graphql.ts
+++ b/api/graphql.ts
@@ -14,7 +14,7 @@ import { HttpError } from "http-errors";
 import fs from "node:fs/promises";
 import { ValidationError } from "validator-fluent";
 import { Context } from "./context";
-import { reportError } from "./core";
+import { log } from "./core";
 import schema from "./schema";
 
 // Customize GraphQL error serialization
@@ -52,14 +52,14 @@ async function handleGraphQL(req: Request, res: Response, next: NextFunction) {
         variables: params.variables,
         request: req,
         schema,
-        contextFactory: () => new Context(req),
+        contextFactory: () => new Context(req, res, params),
       });
 
       sendResult(result, res, (result) => ({
         data: result.data,
         errors: result.errors?.map((err) => {
           if (!(err.originalError instanceof ValidationError)) {
-            reportError(err, req, params);
+            log(req, res, "ERROR", err, params);
           }
           return err;
         }),

--- a/api/mutations/resetPassword.ts
+++ b/api/mutations/resetPassword.ts
@@ -5,7 +5,6 @@ import sgMail, { ResponseError } from "@sendgrid/mail";
 import argon2 from "argon2";
 import { GraphQLFieldConfig, GraphQLObjectType, GraphQLString } from "graphql";
 import { Context } from "../context";
-import { reportError } from "../core";
 import db, { User, UserAction, UserActionType } from "../db";
 import env from "../env";
 import { UserType } from "../types";
@@ -97,7 +96,7 @@ export const resetPassword: GraphQLFieldConfig<unknown, Context> = {
         });
       } catch (err) {
         if (err instanceof ResponseError) {
-          reportError(err, ctx.req, { body: err.response?.body });
+          ctx.log("ERROR", err.response?.body);
         }
         throw new Error("Failed to send the verification code.");
       }

--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^2.1.1",
-    "@google-cloud/logging": "^9.6.9",
     "@google-cloud/storage": "^5.18.1",
     "@sendgrid/mail": "^7.6.1",
     "argon2": "^0.28.4",

--- a/scripts/api-deploy.js
+++ b/scripts/api-deploy.js
@@ -1,15 +1,6 @@
 /* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
 /* SPDX-License-Identifier: MIT */
 
-/**
- * Deploys the "api" package to Google Cloud Functions (GCF). Usage:
- *
- *   $ yarn api:deploy [--env #0]
- *
- * @see https://cloud.google.com/functions
- * @see https://cloud.google.com/sdk/gcloud/reference/functions/deploy
- */
-
 import envars from "envars";
 import minimist from "minimist";
 import { $ } from "zx";
@@ -35,8 +26,16 @@ delete env.PGSSLKEY;
 delete env.PGSSLROOTCERT;
 delete env.PGSERVERNAME;
 
-const name = args.version ? `api_${args.version}` : `api`;
+const name = args.version ? `api-${args.version}` : `api`;
 
+/**
+ * Deploys the "api" package to Google Cloud Functions (GCF). Usage:
+ *
+ *   $ yarn api:deploy [--env #0]
+ *
+ * @see https://cloud.google.com/functions
+ * @see https://cloud.google.com/sdk/gcloud/reference/functions/deploy
+ */
 await $`gcloud beta functions deploy ${name} ${[
   `--project=${process.env.GOOGLE_CLOUD_PROJECT}`,
   `--region=${region}`,

--- a/scripts/img-deploy.js
+++ b/scripts/img-deploy.js
@@ -1,15 +1,6 @@
 /* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
 /* SPDX-License-Identifier: MIT */
 
-/**
- * Deploys the "img" package to Google Cloud Functions (GCF). Usage:
- *
- *   $ yarn img:deploy [--env #0]
- *
- * @see https://cloud.google.com/functions
- * @see https://cloud.google.com/sdk/gcloud/reference/functions/deploy
- */
-
 import envars from "envars";
 import minimist from "minimist";
 import path from "node:path";
@@ -31,6 +22,14 @@ const envVars = [
   `CACHE_BUCKET=${env.CACHE_BUCKET}`,
 ];
 
+/**
+ * Deploys the "img" package to Google Cloud Functions (GCF). Usage:
+ *
+ *   $ yarn img:deploy [--env #0]
+ *
+ * @see https://cloud.google.com/functions
+ * @see https://cloud.google.com/sdk/gcloud/reference/functions/deploy
+ */
 await $`gcloud beta functions deploy img ${[
   `--project=${env.GOOGLE_CLOUD_PROJECT}`,
   `--region=${env.GOOGLE_CLOUD_REGION}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,7 +1763,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google-cloud/common@npm:^3.4.1, @google-cloud/common@npm:^3.8.1":
+"@google-cloud/common@npm:^3.8.1":
   version: 3.9.0
   resolution: "@google-cloud/common@npm:3.9.0"
   dependencies:
@@ -1795,29 +1795,6 @@ __metadata:
     functions-framework: build/src/main.js
     functions-framework-nodejs: build/src/main.js
   checksum: 2192e7b6a2401a6d82dd0c1f3aec54dc6fca21e4980763d47a2d4021da1d1e8628109f9d28b2ad029438cbffe804aecb8fae9bd71ed0684720e8e0a51a652622
-  languageName: node
-  linkType: hard
-
-"@google-cloud/logging@npm:^9.6.9":
-  version: 9.6.9
-  resolution: "@google-cloud/logging@npm:9.6.9"
-  dependencies:
-    "@google-cloud/common": ^3.4.1
-    "@google-cloud/paginator": ^3.0.0
-    "@google-cloud/projectify": ^2.0.0
-    "@google-cloud/promisify": ^2.0.0
-    arrify: ^2.0.1
-    dot-prop: ^6.0.0
-    eventid: ^2.0.0
-    extend: ^3.0.2
-    gcp-metadata: ^4.0.0
-    google-auth-library: ^7.0.0
-    google-gax: ^2.24.1
-    on-finished: ^2.3.0
-    pumpify: ^2.0.1
-    stream-events: ^1.0.5
-    uuid: ^8.0.0
-  checksum: 3cd44c2191f02a65ac273df6b85815d33e0d01340f8a70f5f82ad06ad7106365e98c69e9bbf5080013d1f200c3348aaf36c574cc43f09aa21d08b5463e7014fd
   languageName: node
   linkType: hard
 
@@ -1872,31 +1849,6 @@ __metadata:
     stream-events: ^1.0.4
     xdg-basedir: ^4.0.0
   checksum: 6acde2e9866deb25b392141b70f59cfe21d6acc5c5ed4b92162aec94e53d75a42f459da9a2b13437f70e53ccbf291fed080e55436fc00b6b4dd1c57e77e0b2ec
-  languageName: node
-  linkType: hard
-
-"@grpc/grpc-js@npm:~1.5.0":
-  version: 1.5.5
-  resolution: "@grpc/grpc-js@npm:1.5.5"
-  dependencies:
-    "@grpc/proto-loader": ^0.6.4
-    "@types/node": ">=12.12.47"
-  checksum: ccbe8267c150f98e4047bf74bf436ede71f05136697e6f299c1b9d005d133c6f132d67b392433298df884d9ebd639d08f9845b6cd2bfd9657d5704a78de281d0
-  languageName: node
-  linkType: hard
-
-"@grpc/proto-loader@npm:^0.6.1, @grpc/proto-loader@npm:^0.6.4":
-  version: 0.6.9
-  resolution: "@grpc/proto-loader@npm:0.6.9"
-  dependencies:
-    "@types/long": ^4.0.1
-    lodash.camelcase: ^4.3.0
-    long: ^4.0.0
-    protobufjs: ^6.10.0
-    yargs: ^16.2.0
-  bin:
-    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
-  checksum: 30081a5a6e866506d8e799ebed00367024a2710b9b990104d804fe23c60d81d5ccaa74ad14bd0bedfab6fb313eccbc18e0bbcf3bda7f3288d8eb31cab040255f
   languageName: node
   linkType: hard
 
@@ -2543,79 +2495,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@protobufjs/aspromise@npm:1.1.2"
-  checksum: 011fe7ef0826b0fd1a95935a033a3c0fd08483903e1aa8f8b4e0704e3233406abb9ee25350ec0c20bbecb2aad8da0dcea58b392bbd77d6690736f02c143865d2
-  languageName: node
-  linkType: hard
-
-"@protobufjs/base64@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@protobufjs/base64@npm:1.1.2"
-  checksum: 67173ac34de1e242c55da52c2f5bdc65505d82453893f9b51dc74af9fe4c065cf4a657a4538e91b0d4a1a1e0a0642215e31894c31650ff6e3831471061e1ee9e
-  languageName: node
-  linkType: hard
-
-"@protobufjs/codegen@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@protobufjs/codegen@npm:2.0.4"
-  checksum: 59240c850b1d3d0b56d8f8098dd04787dcaec5c5bd8de186fa548de86b86076e1c50e80144b90335e705a044edf5bc8b0998548474c2a10a98c7e004a1547e4b
-  languageName: node
-  linkType: hard
-
-"@protobufjs/eventemitter@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/eventemitter@npm:1.1.0"
-  checksum: 0369163a3d226851682f855f81413cbf166cd98f131edb94a0f67f79e75342d86e89df9d7a1df08ac28be2bc77e0a7f0200526bb6c2a407abbfee1f0262d5fd7
-  languageName: node
-  linkType: hard
-
-"@protobufjs/fetch@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/fetch@npm:1.1.0"
-  dependencies:
-    "@protobufjs/aspromise": ^1.1.1
-    "@protobufjs/inquire": ^1.1.0
-  checksum: 3fce7e09eb3f1171dd55a192066450f65324fd5f7cc01a431df01bb00d0a895e6bfb5b0c5561ce157ee1d886349c90703d10a4e11a1a256418ff591b969b3477
-  languageName: node
-  linkType: hard
-
-"@protobufjs/float@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@protobufjs/float@npm:1.0.2"
-  checksum: 5781e1241270b8bd1591d324ca9e3a3128d2f768077a446187a049e36505e91bc4156ed5ac3159c3ce3d2ba3743dbc757b051b2d723eea9cd367bfd54ab29b2f
-  languageName: node
-  linkType: hard
-
-"@protobufjs/inquire@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/inquire@npm:1.1.0"
-  checksum: ca06f02eaf65ca36fb7498fc3492b7fc087bfcc85c702bac5b86fad34b692bdce4990e0ef444c1e2aea8c034227bd1f0484be02810d5d7e931c55445555646f4
-  languageName: node
-  linkType: hard
-
-"@protobufjs/path@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@protobufjs/path@npm:1.1.2"
-  checksum: 856eeb532b16a7aac071cacde5c5620df800db4c80cee6dbc56380524736205aae21e5ae47739114bf669ab5e8ba0e767a282ad894f3b5e124197cb9224445ee
-  languageName: node
-  linkType: hard
-
-"@protobufjs/pool@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/pool@npm:1.1.0"
-  checksum: d6a34fbbd24f729e2a10ee915b74e1d77d52214de626b921b2d77288bd8f2386808da2315080f2905761527cceffe7ec34c7647bd21a5ae41a25e8212ff79451
-  languageName: node
-  linkType: hard
-
-"@protobufjs/utf8@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/utf8@npm:1.1.0"
-  checksum: f9bf3163d13aaa3b6f5e6fbf37a116e094ea021c0e1f2a7ccd0e12a29e2ce08dafba4e8b36e13f8ed7397e1591610ce880ed1289af4d66cf4ace8a36a9557278
-  languageName: node
-  linkType: hard
-
 "@rollup/plugin-babel@npm:^5.3.0":
   version: 5.3.0
   resolution: "@rollup/plugin-babel@npm:5.3.0"
@@ -3187,13 +3066,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/long@npm:^4.0.0, @types/long@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@types/long@npm:4.0.1"
-  checksum: ff9653c33f5000d0f131fd98a950a0343e2e33107dd067a97ac4a3b9678e1a2e39ea44772ad920f54ef6e8f107f76bc92c2584ba905a0dc4253282a4101166d0
-  languageName: node
-  linkType: hard
-
 "@types/mime@npm:^1":
   version: 1.3.2
   resolution: "@types/mime@npm:1.3.2"
@@ -3225,7 +3097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:^17.0.18":
+"@types/node@npm:*, @types/node@npm:^17.0.18":
   version: 17.0.18
   resolution: "@types/node@npm:17.0.18"
   checksum: 6c4edfc2b3ba2342a9c3d56e934c5245948ab752f4dc04bd6790b9603e6ebc53bc4f5befc3662e207f7dba2ddd17ccf657f915e319ea7cdd4f77b851079d1611
@@ -4147,7 +4019,6 @@ __metadata:
     "@babel/preset-typescript": ^7.16.7
     "@babel/register": ^7.17.0
     "@google-cloud/functions-framework": ^2.1.1
-    "@google-cloud/logging": ^9.6.9
     "@google-cloud/storage": ^5.18.1
     "@jest/types": ^27.5.1
     "@rollup/plugin-babel": ^5.3.0
@@ -6014,15 +5885,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-prop@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "dot-prop@npm:6.0.1"
-  dependencies:
-    is-obj: ^2.0.0
-  checksum: 0f47600a4b93e1dc37261da4e6909652c008832a5d3684b5bf9a9a0d3f4c67ea949a86dceed9b72f5733ed8e8e6383cc5958df3bbd0799ee317fd181f2ece700
-  languageName: node
-  linkType: hard
-
 "dotenv@npm:^16.0.0":
   version: 16.0.0
   resolution: "dotenv@npm:16.0.0"
@@ -6586,15 +6448,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventid@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "eventid@npm:2.0.1"
-  dependencies:
-    uuid: ^8.0.0
-  checksum: d7de09a0792127796d8ff413e972c0fd2bf52547fd38b7d67bc6dcb10464eb6508f60b92b60e118ecce035586326b2e159be3cec7074fcd5e0e0217c754db3be
-  languageName: node
-  linkType: hard
-
 "events@npm:^3.2.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
@@ -6746,7 +6599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-text-encoding@npm:^1.0.0, fast-text-encoding@npm:^1.0.3":
+"fast-text-encoding@npm:^1.0.0":
   version: 1.0.3
   resolution: "fast-text-encoding@npm:1.0.3"
   checksum: 3e51365896f06d0dcab128092d095a0037d274deec419fecbd2388bc236d7b387610e0c72f920c6126e00c885ab096fbfaa3645712f5b98f721bef6b064916a8
@@ -7148,7 +7001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gcp-metadata@npm:^4.0.0, gcp-metadata@npm:^4.2.0":
+"gcp-metadata@npm:^4.2.0":
   version: 4.3.1
   resolution: "gcp-metadata@npm:4.3.1"
   dependencies:
@@ -7350,7 +7203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"google-auth-library@npm:^7.0.0, google-auth-library@npm:^7.12.0, google-auth-library@npm:^7.6.1, google-auth-library@npm:^7.9.2":
+"google-auth-library@npm:^7.0.0, google-auth-library@npm:^7.12.0, google-auth-library@npm:^7.9.2":
   version: 7.12.0
   resolution: "google-auth-library@npm:7.12.0"
   dependencies:
@@ -7364,29 +7217,6 @@ __metadata:
     jws: ^4.0.0
     lru-cache: ^6.0.0
   checksum: 0c2970ca9b2b5672c7c217e677370f66bccd757e1e70629d9287bfee220fe9ff38e65d3e8377db2abb96a7c86142c32a93a1a817b816d0ba486af84dc1af68e4
-  languageName: node
-  linkType: hard
-
-"google-gax@npm:^2.24.1":
-  version: 2.29.7
-  resolution: "google-gax@npm:2.29.7"
-  dependencies:
-    "@grpc/grpc-js": ~1.5.0
-    "@grpc/proto-loader": ^0.6.1
-    "@types/long": ^4.0.0
-    abort-controller: ^3.0.0
-    duplexify: ^4.0.0
-    fast-text-encoding: ^1.0.3
-    google-auth-library: ^7.6.1
-    is-stream-ended: ^0.1.4
-    node-fetch: ^2.6.1
-    object-hash: ^2.1.1
-    proto3-json-serializer: ^0.1.8
-    protobufjs: 6.11.2
-    retry-request: ^4.0.0
-  bin:
-    compileProtos: build/tools/compileProtos.js
-  checksum: bbca9cbe5cbf74ea66b920d4ed283fa98a451061a692231212d01f2d029d2241b7a5a9e60e93917c1eb3083c869f152c296205d8fafaddb0afc2dd46876efba0
   languageName: node
   linkType: hard
 
@@ -8357,13 +8187,6 @@ __metadata:
   version: 1.0.1
   resolution: "is-shared-array-buffer@npm:1.0.1"
   checksum: 2ffb92533e64e2876e6cfe6906871d28400b6f1a53130fe652ec8007bc0e5044d05e7af8e31bdc992fbba520bd92938cfbeedd0f286be92f250c7c76191c4d90
-  languageName: node
-  linkType: hard
-
-"is-stream-ended@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "is-stream-ended@npm:0.1.4"
-  checksum: 56cbc9cfa0a77877777a3df9e186abb5b0ca73dcbcaf0fd87ed573fb8f8e61283abec0fc072c9e3412336edc04449439b8a128d2bcc6c2797158de5465cfaf85
   languageName: node
   linkType: hard
 
@@ -9455,13 +9278,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.camelcase@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "lodash.camelcase@npm:4.3.0"
-  checksum: cb9227612f71b83e42de93eccf1232feeb25e705bdb19ba26c04f91e885bfd3dd5c517c4a97137658190581d3493ea3973072ca010aab7e301046d90740393d1
-  languageName: node
-  linkType: hard
-
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -9539,13 +9355,6 @@ __metadata:
     chalk: ^4.1.0
     is-unicode-supported: ^0.1.0
   checksum: fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
-  languageName: node
-  linkType: hard
-
-"long@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "long@npm:4.0.0"
-  checksum: 16afbe8f749c7c849db1f4de4e2e6a31ac6e617cead3bdc4f9605cb703cd20e1e9fc1a7baba674ffcca57d660a6e5b53a9e236d7b25a295d3855cca79cc06744
   languageName: node
   linkType: hard
 
@@ -10230,13 +10039,6 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
-  languageName: node
-  linkType: hard
-
-"object-hash@npm:^2.1.1":
-  version: 2.2.0
-  resolution: "object-hash@npm:2.2.0"
-  checksum: 55ba841e3adce9c4f1b9b46b41983eda40f854e0d01af2802d3ae18a7085a17168d6b81731d43fdf1d6bcbb3c9f9c56d22c8fea992203ad90a38d7d919bc28f1
   languageName: node
   linkType: hard
 
@@ -10940,39 +10742,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proto3-json-serializer@npm:^0.1.8":
-  version: 0.1.8
-  resolution: "proto3-json-serializer@npm:0.1.8"
-  dependencies:
-    protobufjs: ^6.11.2
-  checksum: 06bc06e95dee8bed22d83f5915ce5b3aa2ec4aac36ca8fe853acf797dcf0ba4b7020be199631b5c93e49d5af484c0f1bb557521699554fb322702bc3278fb922
-  languageName: node
-  linkType: hard
-
-"protobufjs@npm:6.11.2, protobufjs@npm:^6.10.0, protobufjs@npm:^6.11.2":
-  version: 6.11.2
-  resolution: "protobufjs@npm:6.11.2"
-  dependencies:
-    "@protobufjs/aspromise": ^1.1.2
-    "@protobufjs/base64": ^1.1.2
-    "@protobufjs/codegen": ^2.0.4
-    "@protobufjs/eventemitter": ^1.1.0
-    "@protobufjs/fetch": ^1.1.0
-    "@protobufjs/float": ^1.0.2
-    "@protobufjs/inquire": ^1.1.0
-    "@protobufjs/path": ^1.1.2
-    "@protobufjs/pool": ^1.1.0
-    "@protobufjs/utf8": ^1.1.0
-    "@types/long": ^4.0.1
-    "@types/node": ">=13.7.0"
-    long: ^4.0.0
-  bin:
-    pbjs: bin/pbjs
-    pbts: bin/pbts
-  checksum: 80e9d9610c3eb66f9eae4e44a1ae30381cedb721b7d5f635d781fe4c507e2c77bb7c879addcd1dda79733d3ae589d9e66fd18d42baf99b35df7382a0f9920795
-  languageName: node
-  linkType: hard
-
 "proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
@@ -11018,7 +10787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pumpify@npm:^2.0.0, pumpify@npm:^2.0.1":
+"pumpify@npm:^2.0.0":
   version: 2.0.1
   resolution: "pumpify@npm:2.0.1"
   dependencies:
@@ -11537,7 +11306,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"retry-request@npm:^4.0.0, retry-request@npm:^4.2.2":
+"retry-request@npm:^4.2.2":
   version: 4.2.2
   resolution: "retry-request@npm:4.2.2"
   dependencies:


### PR DESCRIPTION
- Tweak the logging compatibility with Google Cloud Functions (2nd gen)
- Let Google Error Reporting pick up log messages and errors from `stdin` / `stdout` as a simple solution
- Add `ctx.log(...)` helper function to `Context` available from GraphQL resolver functions
- Exclude Node.js native modules and Express related stuff from the error stack traces in development mode

### Usage Example

```typescript
{
  type: UserType,
  resolve(self, args, ctx) {
    ctx.log("INFO", "Fetching user account.");
    
    try {
      /* .... */
    } catch (err) {
      ctx.log("ERROR", err);
    }
  }
}
```

or, from anywhere within the Node.js/Express app:

```typescript
import { log } from "./core";

app.get("/example", (req, res) => {
  log(req, res, "INFO", "Hello from Express app.");
  ...
});
```

**Reference** https://cloud.google.com/functions/docs/monitoring/logging