### PR TITLE
[`api`] Add integration tests using Jest and Supertest

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,6 +19,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      PGHOST: localhost
+      PGPORT: 5432
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: postgres
+
+    services:
+      postgres:
+        image: postgres:14-alpine
+        env:
+          POSTGRES_USER: ${{ env.PGUSER }}
+          POSTGRES_PASSWORD: ${{ env.PGPASSWORD }}
+          POSTGRES_DB: ${{ env.PGDATABASE }}
+        ports:
+          - 5432:5432
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -37,8 +54,9 @@ jobs:
       - run: yarn lint --no-cache
 
       # Test
-      - run: yarn test
       - run: yarn api:tsc
+      - run: yarn db:migrate
+      - run: yarn test
 
       # Compile
       - run: yarn api:build

--- a/api/index.ts
+++ b/api/index.ts
@@ -5,6 +5,7 @@ import SendGrid from "@sendgrid/mail";
 import express from "express";
 import { NotFound } from "http-errors";
 import { auth } from "./auth";
+import db from "./db";
 import env from "./env";
 import { handleError } from "./errors";
 import { handleGraphQL, updateSchema } from "./graphql";
@@ -59,4 +60,4 @@ if (process.env.NODE_ENV === "development") {
   });
 }
 
-export { api, env, updateSchema };
+export { api, db, env, updateSchema };

--- a/api/queries/users.ts
+++ b/api/queries/users.ts
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
+/* SPDX-License-Identifier: MIT */
+
 import { GraphQLFieldConfig } from "graphql";
 import {
   connectionFromArraySlice,

--- a/api/tests/fetch-user.test.ts
+++ b/api/tests/fetch-user.test.ts
@@ -1,0 +1,102 @@
+/* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
+/* SPDX-License-Identifier: MIT */
+
+import request from "supertest";
+import { api, db } from "../index";
+
+beforeAll(async () => {
+  await db
+    .table("user")
+    .insert({
+      id: "test01",
+      username: "test01",
+      email: "test01@example.com",
+    })
+    .onConflict("id")
+    .merge();
+});
+
+afterAll(async () => {
+  await db.table("user").where({ id: "test01" }).delete();
+  await db.destroy();
+});
+
+test(`fetch user(username: "none")`, async () => {
+  const res = await request(api)
+    .post("/api")
+    .send({
+      query: `#graphql
+        query {
+          user(username: "none") { id email username }
+        }
+      `,
+    })
+    .expect(200)
+    .expect("Content-Type", "application/json");
+
+  expect(res.body).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "user": null,
+      },
+    }
+  `);
+});
+
+test(`fetch user(username: "test01")`, async () => {
+  const res = await request(api)
+    .post("/api")
+    .send({
+      query: `#graphql
+        query {
+          user(username: "test01") { id email username }
+        }
+      `,
+    })
+    .expect(200)
+    .expect("Content-Type", "application/json");
+
+  expect(res.body).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "user": Object {
+          "email": null,
+          "id": "VXNlcjp0ZXN0MDE=",
+          "username": "test01",
+        },
+      },
+    }
+  `);
+});
+
+test(`fetch user: node(id: "VXNlcjp0ZXN0MDE=")`, async () => {
+  const res = await request(api)
+    .post("/api")
+    .send({
+      query: `#graphql
+        query {
+          user: node(id: "VXNlcjp0ZXN0MDE=") {
+            ... on User {
+              id
+              email
+              username
+            }
+          }
+        }
+      `,
+    })
+    .expect(200)
+    .expect("Content-Type", "application/json");
+
+  expect(res.body).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "user": Object {
+          "email": null,
+          "id": "VXNlcjp0ZXN0MDE=",
+          "username": "test01",
+        },
+      },
+    }
+  `);
+});

--- a/env/.prod.env
+++ b/env/.prod.env
@@ -35,7 +35,7 @@ PGDATABASE=app_prod
 # PGSSLCERT=../db/ssl/client-cert.prod.pem
 # PGSSLKEY=../db/ssl/client-key.prod.pem
 # PGSSLROOTCERT=../db/ssl/server-ca.prod.pem
-# PGSERVERNAME=example-prod:pg13
+# PGSERVERNAME=example-prod:pg14
 
 # Cloud storage bucket for user uploaded content and static assets
 # https://console.cloud.google.com/storage/browser

--- a/env/.test.env
+++ b/env/.test.env
@@ -35,7 +35,7 @@ PGDATABASE=app_test
 # PGSSLCERT=../db/ssl/client-cert.test.pem
 # PGSSLKEY=../db/ssl/client-key.test.pem
 # PGSSLROOTCERT=../db/ssl/server-ca.test.pem
-# PGSERVERNAME=example-test:pg13
+# PGSERVERNAME=example-test:pg14
 
 # Cloud storage bucket for user uploaded content and static assets
 # https://console.cloud.google.com/storage/browser

--- a/package.json
+++ b/package.json
@@ -96,14 +96,24 @@
     }
   },
   "jest": {
-    "testPathIgnorePatterns": [
-      "<rootDir>/.cache/",
-      "<rootDir>/.github/",
-      "<rootDir>/.vscode/",
-      "<rootDir>/.yarn/",
-      "<rootDir>/*/dist/",
-      "<rootDir>/db/",
-      "<rootDir>/scripts/"
+    "projects": [
+      {
+        "displayName": "api",
+        "testMatch": [
+          "<rootDir>/api/**/*.test.ts"
+        ],
+        "testPathIgnorePatterns": [
+          "<rootDir>/api/dist/"
+        ],
+        "setupFiles": [
+          "envars/config"
+        ],
+        "transformIgnorePatterns": [],
+        "transform": {
+          "^.*[\\\\\\/](api|db)[\\\\\\/].*\\.ts$": "babel-jest",
+          "node_modules[\\\\\\/](got|p-cancelable|@szmarczak|lowercase-keys)[\\\\\\/].*\\.js$": "babel-jest"
+        }
+      }
     ]
   },
   "prettier": {

--- a/setup.js
+++ b/setup.js
@@ -148,7 +148,7 @@ const questions = [
       return (
         replace(`env/.${env}.env`, gcp, `$1=${value}`) &&
         replace(`env/.${env}.env`, db, `$1=${dbName}`) &&
-        replace(`env/.${env}.env`, dbServer, `$1=${value}:pg13`) &&
+        replace(`env/.${env}.env`, dbServer, `$1=${value}:pg14`) &&
         (env === "test"
           ? replace(`env/.local.env`, gcp, `$1=${value}`) &&
             replace(`env/.local.env`, db, `$1=${localDb}`)


### PR DESCRIPTION
- Update Jest configurations to use `projects`
- Pre-load environment variables (from `env/.local.env` file) when running tests (using [`envars`](https://github.com/kriasoft/envars#readme))
- Transpile ESM code to CommonJS since Jest doesn't yet support ESM natively: facebook/jest#4842 including a couple of ESM-only Node.js modules such as `got`
- Add an integration test example using [Jest](https://jestjs.io/) and [Supertest](https://github.com/visionmedia/supertest) /w  inline [snapshots](https://jestjs.io/docs/snapshot-testing)
- Add PostgreSQL service to GitHub Actions workflow (here)

### Testing GraphQL API field (example)

```ts
import request from "supertest";
import { api, db } from "../index";

test(`fetch user(username: "test01")`, async () => {
  const res = await request(api)
    .post("/api")
    .send({
      query: `#graphql
        query {
          user(username: "test01") { id email username }
        }
      `,
    })
    .expect(200)
    .expect("Content-Type", "application/json");

  expect(res.body).toMatchInlineSnapshot(`
    Object {
      "data": Object {
        "user": Object {
          "id": "VXNlcjp0ZXN0MDE=",
          "username": "test01",
          "email": null,
        },
      },
    }
  `);
});
```