### PR TITLE
chore(api): Improve logging and error status code

### DIFF
--- a/.vscode/api.code-snippets
+++ b/.vscode/api.code-snippets
@@ -4,7 +4,7 @@
     "prefix": "query-list",
     "body": [
       "import { GraphQLFieldConfig, GraphQLList, GraphQLNonNull } from \"graphql\";",
-      "import { Context } from \"../context\";",
+      "import { type Context } from \"../context\";",
       "import db, { ${1/^(.)(.*?)s?$/${1:/upcase}$2/} } from \"../db\";",
       "import { ${1/^(.)(.*?)s?$/${1:/upcase}$2/}Type } from \"../types\";",
       "",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "eamodio.gitlens",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
+    "firsttris.vscode-jest-runner",
     "graphql.vscode-graphql",
     "hashicorp.terraform",
     "mgmcdermott.vscode-language-babel",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "jest.jestCommandLine": "yarn jest",
+  "jestrunner.jestCommand": "yarn jest",
   "files.associations": {
     ".terraformrc": "terraform"
   },

--- a/api/auth/session.ts
+++ b/api/auth/session.ts
@@ -4,8 +4,8 @@
 import cookie from "cookie";
 import { Request, RequestHandler, Response } from "express";
 import jwt from "jsonwebtoken";
-import type { User } from "../db";
-import db from "../db";
+import { log } from "../core";
+import db, { User } from "../db";
 import env from "../env";
 
 // The name of the session (ID) cookie.
@@ -26,7 +26,7 @@ async function getUser(req: Request): Promise<User | null> {
       const user = await db.table("user").where({ id: token.sub }).first();
       return user || null;
     } catch (err) {
-      console.error(err);
+      log(req, "WARNING", err as Error);
     }
   }
 
@@ -93,7 +93,7 @@ const session: RequestHandler = async function session(req, res, next) {
       next();
     }
   } catch (err) {
-    console.error(err);
+    log(req, "WARNING", err as Error);
     next();
   }
 };

--- a/api/context.ts
+++ b/api/context.ts
@@ -2,7 +2,7 @@
 /* SPDX-License-Identifier: MIT */
 
 import DataLoader from "dataloader";
-import { type Request, type Response } from "express";
+import { type Request } from "express";
 import { type GraphQLParams } from "graphql-helix";
 import { Forbidden, Unauthorized } from "http-errors";
 import { log, type LogSeverity } from "./core";
@@ -15,13 +15,11 @@ import { mapTo, mapToMany } from "./utils";
  */
 export class Context extends Map<symbol, unknown> {
   readonly #req: Request;
-  readonly #res: Response;
   readonly params: GraphQLParams;
 
-  constructor(req: Request, res: Response, params: GraphQLParams) {
+  constructor(req: Request, params: GraphQLParams) {
     super();
     this.#req = req;
-    this.#res = res;
     this.params = params;
 
     // Add the currently logged in user object to the cache
@@ -35,7 +33,7 @@ export class Context extends Map<symbol, unknown> {
     severity: LogSeverity,
     data: string | Record<string, unknown> | Error,
   ): void {
-    log(this.#req, this.#res, severity, data, this.params);
+    log(this.#req, severity, data, this.params);
   }
 
   /*

--- a/api/graphql.ts
+++ b/api/graphql.ts
@@ -52,14 +52,14 @@ async function handleGraphQL(req: Request, res: Response, next: NextFunction) {
         variables: params.variables,
         request: req,
         schema,
-        contextFactory: () => new Context(req, res, params),
+        contextFactory: () => new Context(req, params),
       });
 
       sendResult(result, res, (result) => ({
         data: result.data,
         errors: result.errors?.map((err) => {
           if (!(err.originalError instanceof ValidationError)) {
-            log(req, res, "ERROR", err, params);
+            log(req, "ERROR", err.originalError ?? err, params);
           }
           return err;
         }),

--- a/db/README.md
+++ b/db/README.md
@@ -19,7 +19,7 @@ a PostgreSQL database.
 │   ├── 01_users.json           #   - user accounts dataset
 │   ├── 01_users.ts             #   - creates user accounts
 │   ├── 02_identities.json      #   - user accounts dataset
-│   ├── id_identities.ts        #   - creates user accounts
+│   ├── 02_identities.ts        #   - creates user accounts
 │   └── ...                     #   - the reset of the seed files
 ├── ssl                         # TLS/SSL certificates for database access
 ├── knexfile.ts                 # Configuration file for Knex.js CLI

--- a/db/package.json
+++ b/db/package.json
@@ -12,8 +12,6 @@
     "db:rollback": "cross-env BABEL_DISABLE_CACHE=1 knex migrate:rollback",
     "db:seed": "cross-env BABEL_DISABLE_CACHE=1 knex seed:run",
     "db:reset": "cross-env BABEL_DISABLE_CACHE=1 babel-node --root-mode=upward -o .,../api -x .ts ./scripts/reset.ts",
-    "db:reset-test": "knex migrate:rollback --env=test 001_initial && knex migrate:latest --env=test && yarn db:restore --env=test",
-    "db:reset-prod": "knex migrate:rollback --env=prod 001_initial && knex migrate:latest --env=prod && yarn db:restore --env=prod",
     "db:backup": "cross-env BABEL_DISABLE_CACHE=1 babel-node --root-mode=upward -x .ts ./scripts/backup.ts",
     "db:restore": "cross-env BABEL_DISABLE_CACHE=1 babel-node --root-mode=upward -x .ts ./scripts/restore.ts",
     "db:import-seeds": "cross-env BABEL_DISABLE_CACHE=1 babel-node --root-mode=upward -o .,../api -x .ts ./scripts/import-seeds.ts",


### PR DESCRIPTION
If you're using `import { log } from "./core"` directly (as opposed `ctx.log(...)`), the `res` argument is now ommited:

```ts
import { log } from "../core";

// BEFORE
log(req, res, "WARNING", "Some text or object");

// AFTER
log(req, "WARNING", "Some text or object")
```

When used inside GraphQL type resolvers, nothing has changed:

```ts
async resolve(self, args, ctx) {
  ctx.log("ERROR", new Error(...));
}
```