### PR TITLE
refactor(api): Session middleware improvements

### DIFF
--- a/api/auth/github.ts
+++ b/api/auth/github.ts
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
 /* SPDX-License-Identifier: MIT */
 
+// import { memoize } from "lodash";
 // import { RequestHandler } from "express";
 // import { App, Octokit } from "octokit";
 // import { IdentityProvider } from "../core";
@@ -8,23 +9,26 @@
 // import authorize from "./authorize";
 
 /**
- * OAuth 2.0 client for GitHub.
+ * Initializes an OAuth 2.0 client for GitHub
  *
  * @see https://github.com/octokit/octokit.js#github-app
  */
-// const app = new App({
-//   appId: env.GITHUB_APP_ID,
-//   privateKey: env.GITHUB_APP_KEY,
-//   oauth: {
-//     clientId: env.GITHUB_CLIENT_ID,
-//     clientSecret: env.GITHUB_CLIENT_SECRET,
-//   },
+// export const getGitHubApp = memoize(function () {
+//   return new App({
+//     appId: env.GITHUB_APP_ID,
+//     privateKey: env.GITHUB_APP_KEY,
+//     oauth: {
+//       clientId: env.GITHUB_CLIENT_ID,
+//       clientSecret: env.GITHUB_CLIENT_SECRET,
+//     },
+//   });
 // });
 
 /**
  * Redirects user to GitHub login page.
  */
 // export const redirect: RequestHandler = function (req, res) {
+//   const app = getGitHubApp();
 //   const authorization = app.oauth.getWebFlowAuthorizationUrl({
 //     redirectUrl: req.app.locals.redirect_uri,
 //     allowSignup: true,
@@ -39,6 +43,7 @@
  */
 // export const callback: RequestHandler = async function (req, res, next) {
 //   try {
+//     const app = getGitHubApp();
 //     const { authentication: credentials } = await app.oauth.createToken({
 //       code: req.query.code as string,
 //       state: req.query.state as string,

--- a/api/core/index.ts
+++ b/api/core/index.ts
@@ -5,5 +5,6 @@ export * from "../../db/types"; // Generated db types
 export * from "../context";
 export * from "./db";
 export * from "./handleError";
+export * from "./jwt";
 export * from "./logging";
 export * from "./storage";

--- a/api/core/jwt.ts
+++ b/api/core/jwt.ts
@@ -1,0 +1,26 @@
+/* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
+/* SPDX-License-Identifier: MIT */
+
+import jwt, { JwtPayload } from "jsonwebtoken";
+import env from "../env";
+
+export function createIdToken(user: { id: string }): string {
+  return jwt.sign({}, env.JWT_SECRET, {
+    issuer: env.APP_ORIGIN,
+    audience: env.APP_NAME,
+    subject: String(user.id),
+    expiresIn: env.JWT_EXPIRES,
+  });
+}
+
+export function verifyIdToken(token: string): JwtPayload {
+  return jwt.verify(token, env.JWT_SECRET, {
+    issuer: env.APP_ORIGIN,
+    audience: env.APP_NAME,
+    complete: false,
+  }) as JwtPayload;
+}
+
+export function decodeIdToken(token: string): JwtPayload | null {
+  return jwt.decode(token, { json: true });
+}

--- a/api/queries/me.test.ts
+++ b/api/queries/me.test.ts
@@ -1,0 +1,56 @@
+/* SPDX-FileCopyrightText: 2016-present Kriasoft <hello@kriasoft.com> */
+/* SPDX-License-Identifier: MIT */
+
+import request from "supertest";
+import { createIdToken, db } from "../core";
+import { api } from "../index";
+
+test(`fetch me (as anonymous)`, async () => {
+  const res = await request(api)
+    .post("/api")
+    .send({
+      query: `#graphql
+        query {
+          me { id email }
+        }
+      `,
+    })
+    .expect(200)
+    .expect("Content-Type", "application/json");
+
+  expect(res.body).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "me": null,
+      },
+    }
+  `);
+});
+
+test(`fetch me (as a registered user)`, async () => {
+  const res = await request(api)
+    .post("/api")
+    .auth(createIdToken({ id: "test1" }), { type: "bearer" })
+    .send({
+      query: `#graphql
+        query {
+          me { id email }
+        }
+      `,
+    })
+    .expect(200)
+    .expect("Content-Type", "application/json");
+
+  expect(res.body).toMatchInlineSnapshot(`
+    Object {
+      "data": Object {
+        "me": Object {
+          "email": "jaylon.johns@example.com",
+          "id": "VXNlcjp0ZXN0MQ==",
+        },
+      },
+    }
+  `);
+});
+
+afterAll(() => db.destroy());


### PR DESCRIPTION
- Update `api/auth/session.ts` (session middleware) to allow authenticating using Google's ID token
- Move JWT related utility functions to `api/core/jwt.ts`
- Initialize Google/Facebook OAuth 2.0 clients on demand (memoize)
- Add a unit test showing how to test protected routes / API endpoints

```ts
import request from "supertest";
import { createIdToken, db } from "../core";
import { api } from "../index";

test(`fetch me (current user)`, async () => {
  const res = await request(api)
    .post("/api")
    .auth(createIdToken({ id: "test1" }), { type: "bearer" })
    .send({
      query: `#graphql
        query {
          me { id email name }
        }
      `,
    })
    .expect(200)
    .expect("Content-Type", "application/json");

  expect(res.body).toMatchInlineSnapshot(`
    Object {
      "data": Object {
        "me": Object {
          "id": "VXNlcjp0ZXN0MQ==",
          "email": "jaylon.johns@example.com",
          "name": "Jaylon Johns",
        },
      },
    }
  `);
});

afterAll(() => db.destroy());
```

See `api/queries/me.test.ts`, `db/seeds/users.json`.