### PR TITLE
fix: Replaces periods in email with underscores when creating a username.

### DIFF
--- a/api/auth/authorize.ts
+++ b/api/auth/authorize.ts
@@ -48,7 +48,8 @@ export default async function authorize(
       identity.email
         ?.substring(0, identity.email?.indexOf("@"))
         .replace(/[^a-zA-Z._]/g, "_")
-        .replace(/__/g, "_") ||
+        .replace(/__/g, "_")
+        .replace(/\./g, "_") ||
       id;
     const usernameAvailable = await db
       .table<User>("user")


### PR DESCRIPTION
Closes #350. 