### PR TITLE
chore: Add `yarn setup` script back to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postinstall": "zx ./scripts/postinstall.js",
     "start": "yarn workspaces foreach -ip -j unlimited run start",
     "build": "yarn workspaces foreach -p -j unlimited run build",
+    "setup": "node ./setup",
     "lint": "eslint --cache --report-unused-disable-directives .",
     "test": "jest",
     "tf": "node --no-warnings ./scripts/tf.js",


### PR DESCRIPTION
This PR adds the yarn 'setup' script definition back to the package.json.  I believe this was removed by mistake.