### PR TITLE
feat(api): Integrate Firebase Auth into GraphiQL IDE

### DIFF
--- a/api/env.ts
+++ b/api/env.ts
@@ -11,7 +11,9 @@ import { bool, cleanEnv, num, str, url } from "envalid";
 export default cleanEnv(process.env, {
   GOOGLE_CLOUD_PROJECT: str(),
   GOOGLE_CLOUD_REGION: str(),
+  FIREBASE_APP_ID: str(),
   FIREBASE_API_KEY: str(),
+  FIREBASE_AUTH_DOMAIN: str(),
 
   APP_NAME: str(),
   APP_ORIGIN: url(),


### PR DESCRIPTION
Appends `Authorization: Bearer <token>` header to requests made via GraphiQL IDE when the user is authenticated.

![image](https://github.com/kriasoft/relay-starter-kit/assets/197134/eb7c1db1-f6a8-42bb-9392-5161722ba559)
