### PR TITLE
fix(app): Authentication (ID) token in the Relay client

### DIFF
--- a/app/core/relay.ts
+++ b/app/core/relay.ts
@@ -1,8 +1,8 @@
 /* SPDX-FileCopyrightText: 2014-present Kriasoft */
 /* SPDX-License-Identifier: MIT */
 
-import { getAuth } from "firebase/auth";
 import { Environment, Network, RecordSource, Store } from "relay-runtime";
+import { getIdToken } from "./auth.js";
 
 /**
  * Initializes a new instance of Relay environment.
@@ -12,12 +12,11 @@ export function createRelay(): Environment {
   // Configure a network layer that fetches data from the GraphQL API
   // https://relay.dev/docs/guides/network-layer/
   const network = Network.create(async function fetchFn(operation, variables) {
-    const auth = getAuth();
     const headers = new Headers({ ["Content-Type"]: "application/json" });
+    const idToken = await getIdToken();
 
     // When the user is authenticated append the ID token to the request
-    if (auth.currentUser) {
-      const idToken = await auth.currentUser.getIdToken();
+    if (idToken) {
       headers.set("Authorization", `Bearer ${idToken}`);
     }
 


### PR DESCRIPTION
Add `getIdToken()` function that can be used outside React components. It's being used inside of Relay client like this:

```tsx
import { Environment, Network, RecordSource, Store } from "relay-runtime";
import { getIdToken } from "./auth.js";

/**
 * Initializes a new instance of Relay environment.
 * @see https://relay.dev/docs/
 */
export function createRelay(): Environment {
  // Configure a network layer that fetches data from the GraphQL API
  // https://relay.dev/docs/guides/network-layer/
  const network = Network.create(async function fetchFn(operation, variables) {
    const headers = new Headers({ ["Content-Type"]: "application/json" });
    const idToken = await getIdToken();

    // When the user is authenticated append the ID token to the request
    if (idToken) {
      headers.set("Authorization", `Bearer ${idToken}`);
    }

    const res = await fetch("/api", {
      method: "POST",
      headers,
      credentials: "include",
      body: JSON.stringify({ query: operation.text, variables }),
    });

    if (!res.ok) {
      throw new HttpError(res.status, res.statusText);
    }

    return await res.json();
  });

  // Initialize Relay records store
  const recordSource = new RecordSource();
  const store = new Store(recordSource);

  return new Environment({ store, network, handlerProvider: null });
}
```
